### PR TITLE
feat: add master-replica database support

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,5 +1,5 @@
 FROM node:20
 WORKDIR /usr/src/app
 COPY server.js .
-RUN npm init -y && npm install express
+RUN npm init -y && npm install express mysql2
 CMD ["node", "server.js"]

--- a/app/server.js
+++ b/app/server.js
@@ -1,6 +1,50 @@
 const express = require("express");
+const mysql = require("mysql2/promise");
+
 const app = express();
 const port = process.env.PORT || 3000;
+
+app.use(express.json());
+
+const dbConfig = {
+  user: process.env.DB_USER || "root",
+  password: process.env.DB_PASSWORD || "rootpass",
+  database: process.env.DB_NAME || "testdb",
+};
+
+const masterPool = mysql.createPool({
+  host: process.env.DB_MASTER_HOST || "db-master",
+  ...dbConfig,
+});
+
+const replicaPool = mysql.createPool({
+  host: process.env.DB_REPLICA_HOST || "db-replica",
+  ...dbConfig,
+});
+
+app.post("/messages", async (req, res) => {
+  const { message } = req.body;
+  try {
+    await masterPool.query(
+      "CREATE TABLE IF NOT EXISTS messages (id INT AUTO_INCREMENT PRIMARY KEY, message VARCHAR(255))"
+    );
+    await masterPool.query("INSERT INTO messages (message) VALUES (?)", [message]);
+    res.status(201).json({ status: "ok" });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: "write failed" });
+  }
+});
+
+app.get("/messages", async (req, res) => {
+  try {
+    const [rows] = await replicaPool.query("SELECT * FROM messages");
+    res.json(rows);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: "read failed" });
+  }
+});
 
 app.get("/", (req, res) => {
   res.send(`Hello from App Server on port ${port}`);


### PR DESCRIPTION
## Summary
- connect Express app to MySQL master and replica pools
- install mysql2 driver in app container
- add endpoints to write messages to master and read from replica

## Testing
- `node --check app/server.js`


------
https://chatgpt.com/codex/tasks/task_e_68bd92f1bdf48325b787bcf8b8eabbac