### PR TITLE
Fix replication setting in MySQL replica config

### DIFF
--- a/db/replica/my.cnf
+++ b/db/replica/my.cnf
@@ -3,4 +3,4 @@ server-id=2
 log-bin=mysql-bin
 gtid_mode=ON
 enforce_gtid_consistency=ON
-binlog_do_db=testdb
+replicate-do-db=testdb


### PR DESCRIPTION
## Summary
- replace deprecated `binlog_do_db` with `replicate-do-db` in replica configuration

## Testing
- `docker ps --format '{{.Names}}'` *(fails: command not found: docker)*
- `docker-compose restart db-replica` *(fails: command not found: docker-compose)*

------
https://chatgpt.com/codex/tasks/task_e_68bdb2a5016883259e40702b19111448