### PR TITLE
Remove binlog_do_db from master config

### DIFF
--- a/db/master/my.cnf
+++ b/db/master/my.cnf
@@ -3,4 +3,3 @@ server-id=1
 log-bin=mysql-bin
 gtid_mode=ON
 enforce_gtid_consistency=ON
-binlog_do_db=testdb


### PR DESCRIPTION
## Summary
- remove `binlog_do_db` setting from master MySQL configuration

## Testing
- `docker-compose restart db-master db-replica` *(fails: command not found)*
- `docker compose restart db-master db-replica` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bdb2a374e88325b3bf385894af7a2d